### PR TITLE
joybus: Fix first bit being skipped when console is being turned on

### DIFF
--- a/examples/GamecubeConsole/main.cpp
+++ b/examples/GamecubeConsole/main.cpp
@@ -1,6 +1,7 @@
 #include "GamecubeConsole.hpp"
 #include "gamecube_definitions.h"
 
+#include <hardware/clocks.h>
 #include <hardware/pio.h>
 #include <pico/stdlib.h>
 

--- a/examples/GamecubeController/main.cpp
+++ b/examples/GamecubeController/main.cpp
@@ -1,6 +1,7 @@
 #include "GamecubeController.hpp"
 #include "gamecube_definitions.h"
 
+#include <hardware/clocks.h>
 #include <hardware/pio.h>
 #include <pico/stdlib.h>
 #include <stdio.h>

--- a/examples/N64Console/main.cpp
+++ b/examples/N64Console/main.cpp
@@ -1,6 +1,7 @@
 #include "N64Console.hpp"
 #include "n64_definitions.h"
 
+#include <hardware/clocks.h>
 #include <hardware/pio.h>
 #include <pico/stdlib.h>
 

--- a/examples/N64Controller/main.cpp
+++ b/examples/N64Controller/main.cpp
@@ -1,6 +1,7 @@
 #include "N64Controller.hpp"
 #include "gamecube_definitions.h"
 
+#include <hardware/clocks.h>
 #include <hardware/pio.h>
 #include <pico/stdlib.h>
 #include <stdio.h>

--- a/include/joybus.pio.h
+++ b/include/joybus.pio.h
@@ -13,48 +13,54 @@
 // ------ //
 
 #define joybus_wrap_target 0
-#define joybus_wrap 22
+#define joybus_wrap 23
+#define joybus_pio_version 1
 
 #define joybus_T1 10
 #define joybus_T2 20
 #define joybus_T3 10
 
 #define joybus_offset_read 0u
-#define joybus_offset_write 5u
+#define joybus_offset_write 6u
 
 static const uint16_t joybus_program_instructions[] = {
             //     .wrap_target
-    0xe080, //  0: set    pindirs, 0                 
-    0x3320, //  1: wait   0 pin, 0               [19]
-    0x4001, //  2: in     pins, 1                    
-    0x20a0, //  3: wait   1 pin, 0                   
-    0x0001, //  4: jmp    1                          
-    0xe081, //  5: set    pindirs, 1                 
-    0xe001, //  6: set    pins, 1                    
-    0x80e0, //  7: pull   ifempty block              
-    0x6021, //  8: out    x, 1                       
-    0x00ee, //  9: jmp    !osre, 14                  
-    0x00b3, // 10: jmp    x != y, 19                 
-    0x80e0, // 11: pull   ifempty block              
-    0x6021, // 12: out    x, 1                       
-    0x000f, // 13: jmp    15                         
-    0xa342, // 14: nop                           [3] 
-    0xa142, // 15: nop                           [1] 
-    0xe900, // 16: set    pins, 0                [9] 
-    0xb201, // 17: mov    pins, x                [18]
-    0x0006, // 18: jmp    6                          
-    0xa442, // 19: nop                           [4] 
-    0xe900, // 20: set    pins, 0                [9] 
-    0xf201, // 21: set    pins, 1                [18]
-    0x0000, // 22: jmp    0                          
+    0xe080, //  0: set    pindirs, 0
+    0x20a0, //  1: wait   1 pin, 0
+    0x3320, //  2: wait   0 pin, 0               [19]
+    0x4001, //  3: in     pins, 1
+    0x20a0, //  4: wait   1 pin, 0
+    0x0002, //  5: jmp    2
+    0xe081, //  6: set    pindirs, 1
+    0xe001, //  7: set    pins, 1
+    0x80e0, //  8: pull   ifempty block
+    0x6021, //  9: out    x, 1
+    0x00ef, // 10: jmp    !osre, 15
+    0x00b4, // 11: jmp    x != y, 20
+    0x80e0, // 12: pull   ifempty block
+    0x6021, // 13: out    x, 1
+    0x0010, // 14: jmp    16
+    0xa342, // 15: nop                           [3]
+    0xa142, // 16: nop                           [1]
+    0xe900, // 17: set    pins, 0                [9]
+    0xb201, // 18: mov    pins, x                [18]
+    0x0007, // 19: jmp    7
+    0xa442, // 20: nop                           [4]
+    0xe900, // 21: set    pins, 0                [9]
+    0xf201, // 22: set    pins, 1                [18]
+    0x0000, // 23: jmp    0
             //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program joybus_program = {
     .instructions = joybus_program_instructions,
-    .length = 23,
+    .length = 24,
     .origin = -1,
+    .pio_version = joybus_pio_version,
+#if PICO_PIO_VERSION > 0
+    .used_gpio_ranges = 0x0
+#endif
 };
 
 static inline pio_sm_config joybus_program_get_default_config(uint offset) {

--- a/include/joybus.pio.h
+++ b/include/joybus.pio.h
@@ -13,7 +13,7 @@
 // ------ //
 
 #define joybus_wrap_target 0
-#define joybus_wrap 27
+#define joybus_wrap 25
 #define joybus_pio_version 1
 
 #define joybus_T1 10
@@ -21,45 +21,43 @@
 #define joybus_T3 10
 
 #define joybus_offset_read 0u
-#define joybus_offset_write 10u
+#define joybus_offset_write 8u
 
 static const uint16_t joybus_program_instructions[] = {
             //     .wrap_target
     0xe080, //  0: set    pindirs, 0
     0x20a0, //  1: wait   1 pin, 0
     0x3320, //  2: wait   0 pin, 0               [19]
-    0xab20, //  3: mov    x, pins                [11]
-    0x00c8, //  4: jmp    pin, 8
+    0x4f01, //  3: in     pins, 1                [15]
+    0x00c2, //  4: jmp    pin, 2
     0xa0c3, //  5: mov    isr, null
     0x20a0, //  6: wait   1 pin, 0
     0x0002, //  7: jmp    2
-    0x4021, //  8: in     x, 1
-    0x0002, //  9: jmp    2
-    0xe081, // 10: set    pindirs, 1
-    0xe001, // 11: set    pins, 1
-    0x80e0, // 12: pull   ifempty block
-    0x6021, // 13: out    x, 1
-    0x00f3, // 14: jmp    !osre, 19
-    0x00b8, // 15: jmp    x != y, 24
-    0x80e0, // 16: pull   ifempty block
-    0x6021, // 17: out    x, 1
-    0x0014, // 18: jmp    20
-    0xa342, // 19: nop                           [3]
-    0xa142, // 20: nop                           [1]
-    0xe900, // 21: set    pins, 0                [9]
-    0xb201, // 22: mov    pins, x                [18]
-    0x000b, // 23: jmp    11
-    0xa442, // 24: nop                           [4]
-    0xe900, // 25: set    pins, 0                [9]
-    0xf201, // 26: set    pins, 1                [18]
-    0x0000, // 27: jmp    0
+    0xe081, //  8: set    pindirs, 1
+    0xe001, //  9: set    pins, 1
+    0x80e0, // 10: pull   ifempty block
+    0x6021, // 11: out    x, 1
+    0x00f1, // 12: jmp    !osre, 17
+    0x00b6, // 13: jmp    x != y, 22
+    0x80e0, // 14: pull   ifempty block
+    0x6021, // 15: out    x, 1
+    0x0012, // 16: jmp    18
+    0xa342, // 17: nop                           [3]
+    0xa142, // 18: nop                           [1]
+    0xe900, // 19: set    pins, 0                [9]
+    0xb201, // 20: mov    pins, x                [18]
+    0x0009, // 21: jmp    9
+    0xa442, // 22: nop                           [4]
+    0xe900, // 23: set    pins, 0                [9]
+    0xf201, // 24: set    pins, 1                [18]
+    0x0000, // 25: jmp    0
             //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program joybus_program = {
     .instructions = joybus_program_instructions,
-    .length = 28,
+    .length = 26,
     .origin = -1,
     .pio_version = joybus_pio_version,
 #if PICO_PIO_VERSION > 0

--- a/include/joybus.pio.h
+++ b/include/joybus.pio.h
@@ -13,7 +13,7 @@
 // ------ //
 
 #define joybus_wrap_target 0
-#define joybus_wrap 23
+#define joybus_wrap 26
 #define joybus_pio_version 1
 
 #define joybus_T1 10
@@ -21,41 +21,44 @@
 #define joybus_T3 10
 
 #define joybus_offset_read 0u
-#define joybus_offset_write 6u
+#define joybus_offset_write 9u
 
 static const uint16_t joybus_program_instructions[] = {
             //     .wrap_target
     0xe080, //  0: set    pindirs, 0
     0x20a0, //  1: wait   1 pin, 0
     0x3320, //  2: wait   0 pin, 0               [19]
-    0x4001, //  3: in     pins, 1
-    0x20a0, //  4: wait   1 pin, 0
-    0x0002, //  5: jmp    2
-    0xe081, //  6: set    pindirs, 1
-    0xe001, //  7: set    pins, 1
-    0x80e0, //  8: pull   ifempty block
-    0x6021, //  9: out    x, 1
-    0x00ef, // 10: jmp    !osre, 15
-    0x00b4, // 11: jmp    x != y, 20
-    0x80e0, // 12: pull   ifempty block
-    0x6021, // 13: out    x, 1
-    0x0010, // 14: jmp    16
-    0xa342, // 15: nop                           [3]
-    0xa142, // 16: nop                           [1]
-    0xe900, // 17: set    pins, 0                [9]
-    0xb201, // 18: mov    pins, x                [18]
-    0x0007, // 19: jmp    7
-    0xa442, // 20: nop                           [4]
-    0xe900, // 21: set    pins, 0                [9]
-    0xf201, // 22: set    pins, 1                [18]
-    0x0000, // 23: jmp    0
+    0xab20, //  3: mov    x, pins                [11]
+    0x00c7, //  4: jmp    pin, 7
+    0x20a0, //  5: wait   1 pin, 0
+    0x0002, //  6: jmp    2
+    0x4021, //  7: in     x, 1
+    0x0002, //  8: jmp    2
+    0xe081, //  9: set    pindirs, 1
+    0xe001, // 10: set    pins, 1
+    0x80e0, // 11: pull   ifempty block
+    0x6021, // 12: out    x, 1
+    0x00f2, // 13: jmp    !osre, 18
+    0x00b7, // 14: jmp    x != y, 23
+    0x80e0, // 15: pull   ifempty block
+    0x6021, // 16: out    x, 1
+    0x0013, // 17: jmp    19
+    0xa342, // 18: nop                           [3]
+    0xa142, // 19: nop                           [1]
+    0xe900, // 20: set    pins, 0                [9]
+    0xb201, // 21: mov    pins, x                [18]
+    0x000a, // 22: jmp    10
+    0xa442, // 23: nop                           [4]
+    0xe900, // 24: set    pins, 0                [9]
+    0xf201, // 25: set    pins, 1                [18]
+    0x0000, // 26: jmp    0
             //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program joybus_program = {
     .instructions = joybus_program_instructions,
-    .length = 24,
+    .length = 27,
     .origin = -1,
     .pio_version = joybus_pio_version,
 #if PICO_PIO_VERSION > 0
@@ -76,6 +79,7 @@ static inline pio_sm_config joybus_program_get_config(PIO pio, uint sm, uint off
     sm_config_set_out_pins(&c, pin, 1);
     sm_config_set_set_pins(&c, pin, 1);
     sm_config_set_in_pins(&c, pin);
+    sm_config_set_jmp_pin(&c, pin);
     // Shift to left, no autopull, 9 bit
     sm_config_set_out_shift(&c, false, false, 9);
     // Shift to left, autopush, 8 bit

--- a/include/joybus.pio.h
+++ b/include/joybus.pio.h
@@ -13,7 +13,7 @@
 // ------ //
 
 #define joybus_wrap_target 0
-#define joybus_wrap 26
+#define joybus_wrap 27
 #define joybus_pio_version 1
 
 #define joybus_T1 10
@@ -21,7 +21,7 @@
 #define joybus_T3 10
 
 #define joybus_offset_read 0u
-#define joybus_offset_write 9u
+#define joybus_offset_write 10u
 
 static const uint16_t joybus_program_instructions[] = {
             //     .wrap_target
@@ -29,36 +29,37 @@ static const uint16_t joybus_program_instructions[] = {
     0x20a0, //  1: wait   1 pin, 0
     0x3320, //  2: wait   0 pin, 0               [19]
     0xab20, //  3: mov    x, pins                [11]
-    0x00c7, //  4: jmp    pin, 7
-    0x20a0, //  5: wait   1 pin, 0
-    0x0002, //  6: jmp    2
-    0x4021, //  7: in     x, 1
-    0x0002, //  8: jmp    2
-    0xe081, //  9: set    pindirs, 1
-    0xe001, // 10: set    pins, 1
-    0x80e0, // 11: pull   ifempty block
-    0x6021, // 12: out    x, 1
-    0x00f2, // 13: jmp    !osre, 18
-    0x00b7, // 14: jmp    x != y, 23
-    0x80e0, // 15: pull   ifempty block
-    0x6021, // 16: out    x, 1
-    0x0013, // 17: jmp    19
-    0xa342, // 18: nop                           [3]
-    0xa142, // 19: nop                           [1]
-    0xe900, // 20: set    pins, 0                [9]
-    0xb201, // 21: mov    pins, x                [18]
-    0x000a, // 22: jmp    10
-    0xa442, // 23: nop                           [4]
-    0xe900, // 24: set    pins, 0                [9]
-    0xf201, // 25: set    pins, 1                [18]
-    0x0000, // 26: jmp    0
+    0x00c8, //  4: jmp    pin, 8
+    0xa0c3, //  5: mov    isr, null
+    0x20a0, //  6: wait   1 pin, 0
+    0x0002, //  7: jmp    2
+    0x4021, //  8: in     x, 1
+    0x0002, //  9: jmp    2
+    0xe081, // 10: set    pindirs, 1
+    0xe001, // 11: set    pins, 1
+    0x80e0, // 12: pull   ifempty block
+    0x6021, // 13: out    x, 1
+    0x00f3, // 14: jmp    !osre, 19
+    0x00b8, // 15: jmp    x != y, 24
+    0x80e0, // 16: pull   ifempty block
+    0x6021, // 17: out    x, 1
+    0x0014, // 18: jmp    20
+    0xa342, // 19: nop                           [3]
+    0xa142, // 20: nop                           [1]
+    0xe900, // 21: set    pins, 0                [9]
+    0xb201, // 22: mov    pins, x                [18]
+    0x000b, // 23: jmp    11
+    0xa442, // 24: nop                           [4]
+    0xe900, // 25: set    pins, 0                [9]
+    0xf201, // 26: set    pins, 1                [18]
+    0x0000, // 27: jmp    0
             //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program joybus_program = {
     .instructions = joybus_program_instructions,
-    .length = 27,
+    .length = 28,
     .origin = -1,
     .pio_version = joybus_pio_version,
 #if PICO_PIO_VERSION > 0

--- a/src/joybus.pio
+++ b/src/joybus.pio
@@ -8,6 +8,7 @@
 ; Autopush with 8 bit ISR threshold
 public read:
     set pindirs 0                   ; Set pin to input
+    wait 1 pin 0                    ; Make sure the line is high before entering the loop
 read_loop:
     wait 0 pin 0 [T1 + T2 / 2 - 1]  ; Wait for falling edge, then wait until halfway through the 2uS which represents the bit value
     in pins, 1                      ; Read bit value

--- a/src/joybus.pio
+++ b/src/joybus.pio
@@ -12,8 +12,8 @@ public read:
 read_loop:
     wait 0 pin 0 [T1 + T2 / 2 - 1]  ; Wait for falling edge, then wait until halfway through the 2uS which represents the bit value
     in pins, 1 [T2 / 2 + T3 / 2]    ; Read bit value, then wait until halfway through the expected rising edge
-    jmp pin read_loop               ; Push the bit value and continue the loop if there was a rising edge
-    mov isr, null                   ; Line was pulled low, thus we should empty the input shift register
+    jmp pin read_loop               ; Continue the loop if there was a rising edge, if not then restart the loop
+    mov isr, null                   ; Line was pulled low, thus we should restart the loop by emptying the input shift register
     wait 1 pin 0                    ; Make sure we wait for the line to go high again before restarting the loop
     jmp read_loop
 

--- a/src/joybus.pio
+++ b/src/joybus.pio
@@ -11,8 +11,12 @@ public read:
     wait 1 pin 0                    ; Make sure the line is high before entering the loop
 read_loop:
     wait 0 pin 0 [T1 + T2 / 2 - 1]  ; Wait for falling edge, then wait until halfway through the 2uS which represents the bit value
-    in pins, 1                      ; Read bit value
-    wait 1 pin 0                    ; Done reading, so make sure we wait for the line to go high again before restarting the loop
+    mov x, pins [T2 / 2 + 1]        ; Read bit value, then wait until the expected rising edge
+    jmp pin read_push               ; Push the bit value and continue the loop if there was a rising edge
+    wait 1 pin 0                    ; Console turned off, so make sure we wait for the line to go high again before continuing the loop
+    jmp read_loop
+read_push:
+    in x, 1                         ; Push bit value
     jmp read_loop
 
 
@@ -52,6 +56,7 @@ static inline pio_sm_config joybus_program_get_config(PIO pio, uint sm, uint off
     sm_config_set_out_pins(&c, pin, 1);
     sm_config_set_set_pins(&c, pin, 1);
     sm_config_set_in_pins(&c, pin);
+    sm_config_set_jmp_pin(&c, pin);
     // Shift to left, no autopull, 9 bit
     sm_config_set_out_shift(&c, false, false, 9);
     // Shift to left, autopush, 8 bit

--- a/src/joybus.pio
+++ b/src/joybus.pio
@@ -13,7 +13,8 @@ read_loop:
     wait 0 pin 0 [T1 + T2 / 2 - 1]  ; Wait for falling edge, then wait until halfway through the 2uS which represents the bit value
     mov x, pins [T2 / 2 + 1]        ; Read bit value, then wait until the expected rising edge
     jmp pin read_push               ; Push the bit value and continue the loop if there was a rising edge
-    wait 1 pin 0                    ; Console turned off, so make sure we wait for the line to go high again before continuing the loop
+    mov isr, null                   ; Line was pulled low, thus we should empty the input shift register
+    wait 1 pin 0                    ; Make sure we wait for the line to go high again before restarting the loop
     jmp read_loop
 read_push:
     in x, 1                         ; Push bit value

--- a/src/joybus.pio
+++ b/src/joybus.pio
@@ -11,7 +11,7 @@ public read:
     wait 1 pin 0                    ; Make sure the line is high before entering the loop
 read_loop:
     wait 0 pin 0 [T1 + T2 / 2 - 1]  ; Wait for falling edge, then wait until halfway through the 2uS which represents the bit value
-    mov x, pins [T2 / 2 + 1]        ; Read bit value, then wait until the expected rising edge
+    mov x, pins [T2 / 2 + T3 / 2]   ; Read bit value, then wait until halfway through the expected rising edge
     jmp pin read_push               ; Push the bit value and continue the loop if there was a rising edge
     mov isr, null                   ; Line was pulled low, thus we should empty the input shift register
     wait 1 pin 0                    ; Make sure we wait for the line to go high again before restarting the loop

--- a/src/joybus.pio
+++ b/src/joybus.pio
@@ -11,13 +11,10 @@ public read:
     wait 1 pin 0                    ; Make sure the line is high before entering the loop
 read_loop:
     wait 0 pin 0 [T1 + T2 / 2 - 1]  ; Wait for falling edge, then wait until halfway through the 2uS which represents the bit value
-    mov x, pins [T2 / 2 + T3 / 2]   ; Read bit value, then wait until halfway through the expected rising edge
-    jmp pin read_push               ; Push the bit value and continue the loop if there was a rising edge
+    in pins, 1 [T2 / 2 + T3 / 2]    ; Read bit value, then wait until halfway through the expected rising edge
+    jmp pin read_loop               ; Push the bit value and continue the loop if there was a rising edge
     mov isr, null                   ; Line was pulled low, thus we should empty the input shift register
     wait 1 pin 0                    ; Make sure we wait for the line to go high again before restarting the loop
-    jmp read_loop
-read_push:
-    in x, 1                         ; Push bit value
     jmp read_loop
 
 


### PR DESCRIPTION
When the console is being turned on the data line is initially low because the console is powered off. This causes joybus-pio to incorrectly conclude that the first MSB bit is 0. The simple fix for this issue is to wait until the data line becomes high before entering the read loop.

However this doesn't work if the console is reset, since we are already in the loop by then. Thus for a complete fix we need to detect if the data line actually returns to a high value, if it doesn't then we should reset the loop by emptying the ISR and waiting for the data line to become high again.

I also included a trivial commit that includes a missing header in the examples.